### PR TITLE
Feature: #8 - 공용으로 사용되는 UIBarButtomItem 구현 

### DIFF
--- a/Beontteuk/Presentation/Shared/ViewComponent/CustomUIBarButtonItem.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/CustomUIBarButtonItem.swift
@@ -1,0 +1,61 @@
+//
+//  CustomUIBarButtonItem.swift
+//  Beontteuk
+//
+//  Created by yimkeul on 5/21/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+enum NavigationButtonType {
+    case edit(action: () -> Void)
+    case check(action: () -> Void)
+}
+
+final class CustomUIBarButtonItem: UIBarButtonItem {
+
+    convenience init(type: NavigationButtonType) {
+        let button = UIButton().then {
+
+            $0.tintColor = .primary300
+
+            let size: CGFloat = 40
+            $0.frame = CGRect(x: 0, y: 0, width: size, height: size)
+            $0.backgroundColor = .neutral100
+            $0.layer.cornerRadius = size / 2
+
+            $0.layer.shadowColor = UIColor.black.cgColor
+            $0.layer.shadowOpacity = 0.25
+            $0.layer.shadowRadius = 5
+            $0.layer.shadowOffset = CGSize(width: 1, height: 2.5)
+
+        }
+
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .bold)
+
+        switch type {
+        case .edit(let action):
+            let trashMark = UIImage(
+                systemName: "trash",
+                withConfiguration: symbolConfig
+            )
+
+            button.setImage(trashMark, for: .normal)
+            button.addAction(UIAction { _ in action() }, for: .touchUpInside)
+
+        case .check(let action):
+            let checkMark = UIImage(
+                systemName: "checkmark",
+                withConfiguration: symbolConfig
+            )
+
+            button.setImage(checkMark, for: .normal)
+            button.addAction(UIAction { _ in action() }, for: .touchUpInside)
+        }
+
+        self.init(customView: button)
+    }
+}


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - Shared/ViewComponent에 UIBarButtonItem 구현

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
테스트를 진행하려면 SceneDelegate에 NavigationController를 추가하고
사용할 ViewController에 

```
navigationItem.leftBarButtonItem =
        CustomUIBarButtonItem(type: .edit(action: {
            print("edit")
        }))

navigationItem.rightBarButtonItem =
        CustomUIBarButtonItem(type: .check(action: {
            print("check")
        }))
```
로 테스트 가능

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone - 16 Pro| <img src = "https://github.com/user-attachments/assets/2550df72-479d-472a-9f1a-9e34e711b1db" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #8
