### PR TITLE
Feature:#10 - 공용으로 사용되는 DefaultButton 구현

### DIFF
--- a/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
@@ -1,0 +1,88 @@
+//
+//  DefaultButton.swift
+//  Beontteuk
+//
+//  Created by kingj on 5/21/25.
+//
+
+import UIKit
+import SnapKit
+
+final class DefaultButton: UIButton {
+
+    init(type: DefaultButtonType) {
+        super.init(frame: .zero)
+
+        var config = UIButton.Configuration.filled()
+
+        switch type {
+        case .reset, .start, .lap, .stop, .cancel:
+            config.baseForegroundColor = type.fgColor
+            config.baseBackgroundColor = type.bgColor
+            config.cornerStyle = .capsule
+            config.attributedTitle = {
+                var attributedTitle = AttributedString(type.text)
+                attributedTitle.font = UIFont.systemFont(ofSize: type.fontSize, weight: .medium)
+                return attributedTitle
+            }()
+            config.titleAlignment = .center
+
+            self.configuration = config
+            self.snp.makeConstraints {
+                $0.height.equalTo(type.height)
+            }
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension DefaultButton {
+    enum DefaultButtonType {
+        case reset
+        case start
+        case lap
+        case stop
+        case cancel
+
+        var text: String {
+            switch self {
+            case .reset: return "재설정"
+            case .start: return "시작"
+            case .lap: return "랩"
+            case .stop: return "중단"
+            case .cancel: return "취소"
+            }
+        }
+
+        var fgColor: UIColor {
+            switch self {
+            case .reset: return .neutral1000
+            case .start: return .neutral100
+            case .lap: return .neutral1000
+            case .stop: return .neutral100
+            case .cancel: return .neutral1000
+            }
+        }
+
+        var bgColor: UIColor {
+            switch self {
+            case .reset: return .neutral100
+            case .start: return .primary500
+            case .lap: return .neutral100
+            case .stop: return .neutral700
+            case .cancel: return .neutral100
+            }
+        }
+
+        var height: Int {
+            return 60
+        }
+
+        var fontSize: CGFloat {
+            return 24
+        }
+    }
+}

--- a/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
@@ -19,7 +19,6 @@ final class DefaultButton: UIButton {
         case .reset, .start, .lap, .stop, .cancel:
             config.baseForegroundColor = type.fgColor
             config.baseBackgroundColor = type.bgColor
-            config.cornerStyle = .capsule
             config.attributedTitle = {
                 var attributedTitle = AttributedString(type.text)
                 attributedTitle.font = UIFont.systemFont(ofSize: type.fontSize, weight: .medium)
@@ -28,6 +27,9 @@ final class DefaultButton: UIButton {
             config.titleAlignment = .center
 
             self.configuration = config
+            self.layer.cornerRadius = 16
+            self.clipsToBounds = true
+
             self.snp.makeConstraints {
                 $0.height.equalTo(type.height)
             }


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 공용 DefaultButton 구현 
 - 생성 시 type을 인자로 받습니다.

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- 테스트 시 아래의 코드를 사용해주세요.
- 특이사항
   - height 사이즈가 포함되어있어, 값을 안줘도 됨
   - 테스트를 위해 `UIColor.gray` 로 색 지정하였음
   ```swift
    import UIKit
    import SnapKit
    import Then

    class ViewController: UIViewController {

        override func viewDidLoad() {
            super.viewDidLoad()

            let stackView = UIStackView().then {
                $0.axis = .horizontal
                $0.spacing = 24
            }

            let resetButton = DefaultButton(type: .reset)
            let startButton = DefaultButton(type: .start)
    
            [
                stackView
            ]
                .forEach { view.addSubview($0) }

            [
                resetButton,
                startButton
            ]
                .forEach { stackView.addArrangedSubview($0) }

            stackView.snp.makeConstraints {
                $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
                $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(28)
            }
        }
    }
   ```

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone - 16 pro | <img src = "https://github.com/user-attachments/assets/29dd6570-1e82-4cab-999a-aab45cfdf518" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #10 
