### PR TITLE
Fix: #18 - 버튼에 그림자가 적용되지 않던 버그 해결

### DIFF
--- a/Beontteuk/Presentation/Shared/Extension/Extension.swift
+++ b/Beontteuk/Presentation/Shared/Extension/Extension.swift
@@ -49,9 +49,7 @@ extension UIView {
 
     /// View의 Layer에 그림자를 적용합니다.
     ///
-    /// 이 메서드만드로는 shadowPath가 적용되지 않아, 매 프레임마다 shadowPath를 결정하게 되어 GPU 부하가 커지기 때문에 View의 bounds가 결정된 후 path를 설정해주어야 합니다. 즉, layoutSubViews에서 updateShadowPath()를 꼭 호출해주어야 합니다.
-    ///
-    /// 예시:
+    /// 이 메서드를 호출하는 것만으로는 shadowPath가 적용되지 않아, 매 프레임마다 shadowPath를 결정하게 되어 GPU 부하가 커지기 때문에 View의 bounds가 결정된 후 path를 설정해주어야 합니다. 즉, layoutSubViews에서 updateShadowPath()를 꼭 호출해주어야 합니다. 예시:
     ///
     /// ```swift
     /// let myView: UIView() = {

--- a/Beontteuk/Presentation/Shared/Extension/Extension.swift
+++ b/Beontteuk/Presentation/Shared/Extension/Extension.swift
@@ -47,12 +47,36 @@ extension UIView {
             .forEach { $0.frame = bounds }
     }
 
-    /// layer에 그림자를 적용합니다.
+    /// View의 Layer에 그림자를 적용합니다.
+    ///
+    /// 이 메서드만드로는 shadowPath가 적용되지 않아, 매 프레임마다 shadowPath를 결정하게 되어 GPU 부하가 커지기 때문에 View의 bounds가 결정된 후 path를 설정해주어야 합니다. 즉, layoutSubViews에서 updateShadowPath()를 꼭 호출해주어야 합니다.
+    ///
+    /// 예시:
+    ///
+    /// ```swift
+    /// let myView: UIView() = {
+    ///     let view = UIView()
+    ///     view.setShadow(type: .large)
+    ///     return view
+    /// }()
+    ///
+    /// override func layoutSubviews() {
+    ///     super.layoutSubviews()
+    ///     myView.updateShadowPath()
+    /// }
+    /// ```
     func setShadow(type: ShadowSize) {
         layer.shadowColor = UIColor.neutral1000.cgColor
         layer.shadowRadius = 5
         layer.shadowOffset = type.offset
         layer.shadowOpacity = 0.25
+    }
+
+    func updateShadowPath() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: layer.cornerRadius).cgPath
+        }
     }
 
     enum ShadowSize {

--- a/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
@@ -22,9 +22,9 @@ final class AddButton: UIButton {
 
     private func setStyles() {
         layer.cornerRadius = 16
-        clipsToBounds = true
+        backgroundColor = .neutral100
 
-        var config = UIButton.Configuration.filled()
+        var config = UIButton.Configuration.plain()
 
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 25, weight: .medium)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)?
@@ -37,7 +37,6 @@ final class AddButton: UIButton {
         ]))
         config.attributedTitle = attributedTitle
 
-        config.baseBackgroundColor = .neutral100
         config.imagePadding = 8
         config.contentInsets = .init(top: 12, leading: 24, bottom: 12, trailing: 24)
 
@@ -58,3 +57,4 @@ extension AddButton {
         }
     }
 }
+

--- a/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
@@ -13,22 +13,25 @@ final class DefaultButton: UIButton {
     init(type: DefaultButtonType) {
         super.init(frame: .zero)
 
-        var config = UIButton.Configuration.filled()
+        var config = UIButton.Configuration.plain()
 
         switch type {
         case .reset, .start, .lap, .stop, .cancel:
             config.baseForegroundColor = type.fgColor
-            config.baseBackgroundColor = type.bgColor
+            config.titleAlignment = .center
             config.attributedTitle = {
                 var attributedTitle = AttributedString(type.text)
-                attributedTitle.font = UIFont.systemFont(ofSize: type.fontSize, weight: .medium)
+                attributedTitle.font = UIFont.systemFont(
+                    ofSize: type.fontSize,
+                    weight: .medium
+                )
                 return attributedTitle
             }()
-            config.titleAlignment = .center
 
             self.configuration = config
             self.layer.cornerRadius = 16
-            self.clipsToBounds = true
+            self.backgroundColor = type.bgColor
+            self.setShadow(type: .large)
 
             self.snp.makeConstraints {
                 $0.height.equalTo(type.height)


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
- `AddButton`, `DefaultButton`에서 그림자가 적용되지 않던 버그를 해결했습니다.
- 그림자 추가 시 `shadowPath`를 설정하지 않아 GPU 부하가 커지는 성능 이슈를 해결했습니다.

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
 - 버튼의 `Configuration`를 `filled`에서 `plain`으로 변경하여 배경색 설정을 `Configuration.baseBackgroundColor`가 아닌 버튼 자체적으로 `backgroundColor`와 `cornerRadius`를 설정하여 `clipsToBounds`를 사용하지 않도록 함으로써 그림자에 대한 layer 설정이 적용될 수 있도록 수정했습니다.
 - `setShadow(type:)` 사용 시 `updateShadowPath()`를 `layoutSubviews()`에서 호출해야합니다. 메서드 사용시 퀵헬프를 통해 관련 내용을 확인할 수 있습니다.

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #18
