### PR TITLE
Feature: #2 - 타이머 UI 구현

### DIFF
--- a/Beontteuk.xcodeproj/xcshareddata/xcschemes/Beontteuk.xcscheme
+++ b/Beontteuk.xcodeproj/xcshareddata/xcschemes/Beontteuk.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "149B2A112DDC263A005EA674"
+               BuildableName = "Beontteuk.app"
+               BlueprintName = "Beontteuk"
+               ReferencedContainer = "container:Beontteuk.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "149B2A2A2DDC263B005EA674"
+               BuildableName = "BeontteukTests.xctest"
+               BlueprintName = "BeontteukTests"
+               ReferencedContainer = "container:Beontteuk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "149B2A342DDC263B005EA674"
+               BuildableName = "BeontteukUITests.xctest"
+               BlueprintName = "BeontteukUITests"
+               ReferencedContainer = "container:Beontteuk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "149B2A112DDC263A005EA674"
+            BuildableName = "Beontteuk.app"
+            BlueprintName = "Beontteuk"
+            ReferencedContainer = "container:Beontteuk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "149B2A112DDC263A005EA674"
+            BuildableName = "Beontteuk.app"
+            BlueprintName = "Beontteuk"
+            ReferencedContainer = "container:Beontteuk.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Beontteuk/Presentation/Timer/View/Model/TimerItem.swift
+++ b/Beontteuk/Presentation/Timer/View/Model/TimerItem.swift
@@ -1,0 +1,51 @@
+//
+//  TimerItem.swift
+//  Beontteuk
+//
+//  Created by 곽다은 on 5/22/25.
+//
+
+import Foundation
+
+enum TimerItem: Hashable {
+    case current(CurrentTimer)
+    case recent(RecentTimer)
+
+    var current: CurrentTimer? {
+        if case .current(let currentTimer) = self {
+            return currentTimer
+        } else {
+            return nil
+        }
+    }
+
+    var recent: RecentTimer? {
+        if case .recent(let recentTimer) = self {
+            return recentTimer
+        } else {
+            return nil
+        }
+    }
+
+    static let currentItems: [TimerItem] = [
+        .current(CurrentTimer(time: "03:30", timeKR: "3분 30초", progress: 0.7)),
+        .current(CurrentTimer(time: "07:30", timeKR: "7분 30초", progress: 1)),
+        .current(CurrentTimer(time: "13:20", timeKR: "13분 20초", progress: 0.2))
+    ]
+
+    static let recentItems: [TimerItem] = [
+        .recent(RecentTimer(time: "5:00", timeKR: "5분")),
+        .recent(RecentTimer(time: "2:09:30", timeKR: "2시간 9분 30초"))
+    ]
+}
+
+struct CurrentTimer: Hashable {
+    let time: String
+    let timeKR: String
+    let progress: CGFloat
+}
+
+struct RecentTimer: Hashable {
+    let time: String
+    let timeKR: String
+}

--- a/Beontteuk/Presentation/Timer/View/Model/TimerItem.swift
+++ b/Beontteuk/Presentation/Timer/View/Model/TimerItem.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+enum TimerSection: Hashable, CaseIterable {
+    case current
+    case recent
+}
+
 enum TimerItem: Hashable {
     case current(CurrentTimer)
     case recent(RecentTimer)

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
@@ -93,13 +93,7 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
         addButton.updateShadowPath()
         cancelButton.updateShadowPath()
         startButton.updateShadowPath()
-
-        timeStackView.snp.removeConstraints()
-        timeStackView.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 36)
-            $0.centerY.equalToSuperview()
-            $0.width.equalToSuperview().inset(8)
-        }
+        layoutTimeStackView()
     }
 
     // MARK: - Layout Helper
@@ -124,13 +118,30 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
         }
 
         bellImageView.snp.makeConstraints {
-            $0.size.equalTo(190)
+            $0.height.equalTo(190)
         }
 
         addStackView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.directionalHorizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(32)
+        }
+
+        timeStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 36)
+            $0.centerY.equalToSuperview()
+            $0.width.equalToSuperview().inset(8)
+        }
+    }
+
+    // MARK: - Methods
+
+    private func layoutTimeStackView() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            timeStackView.snp.updateConstraints {
+                $0.leading.equalToSuperview().inset(self.timePicker.rowSize(forComponent: 0).width / 2 + 36)
+            }
         }
     }
 }

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
@@ -16,7 +16,7 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
     // Idle
     private let idleStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 32
+        $0.spacing = 20
         $0.isHidden = true
     }
 
@@ -112,23 +112,32 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
         timeStackView.addArrangedSubviews(hourLabel, munuteLabel, secondLabel)
 
         idleStackView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(32)
+            $0.top.equalToSuperview().inset(32)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16).priority(.high)
+            $0.height.equalTo(270)
         }
 
         bellImageView.snp.makeConstraints {
             $0.height.equalTo(190)
         }
 
+        addButton.snp.makeConstraints {
+            $0.height.equalTo(60)
+        }
+
         addStackView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(32)
+            $0.top.equalToSuperview().inset(32)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(270)
+        }
+
+        timePicker.snp.makeConstraints {
+            $0.height.equalTo(190)
         }
 
         timeStackView.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 36)
+            let inset = timePicker.rowSize(forComponent: 0).width / 2 + 36
+            $0.leading.equalToSuperview().inset(inset)
             $0.centerY.equalToSuperview()
             $0.width.equalToSuperview().inset(8)
         }
@@ -144,10 +153,17 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
             }
         }
     }
+
+    // MARK: - Methods
+
+    func updateState(to state: AddState) {
+        idleStackView.isHidden = state != .idle
+        addStackView.isHidden = state != .add
+    }
 }
 
 extension TimerAddHeader {
-    enum State {
+    enum AddState {
         case idle
         case add
     }

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
@@ -1,0 +1,157 @@
+//
+//  TimerAddHeader.swift
+//  Beontteuk
+//
+//  Created by 곽다은 on 5/22/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class TimerAddHeader: BaseTableViewHeaderFooterView {
+
+    // MARK: - UI Components
+
+    // Idle
+    private let idleStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 32
+        $0.isHidden = true
+    }
+
+    private let bellImageView = UIImageView().then {
+        $0.image = .timerOff
+        $0.contentMode = .scaleAspectFit
+    }
+
+    private let addButton = AddButton(type: .timer).then {
+        $0.setShadow(type: .large)
+    }
+
+    // Add
+    private let addStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 20
+        $0.isHidden = false
+    }
+
+    private let timePicker = UIPickerView()
+
+    private let timeStackView = UIStackView().then {
+        $0.distribution = .fillEqually
+    }
+
+    private let hourLabel = UILabel().then {
+        $0.text = "시간"
+        $0.font = UIFont.boldSystemFont(ofSize: 20)
+        $0.textColor = .neutral1000
+    }
+
+    private let munuteLabel = UILabel().then {
+        $0.text = "분"
+        $0.font = UIFont.boldSystemFont(ofSize: 20)
+        $0.textColor = .neutral1000
+    }
+
+    private let secondLabel = UILabel().then {
+        $0.text = "초"
+        $0.font = UIFont.boldSystemFont(ofSize: 20)
+        $0.textColor = .neutral1000
+    }
+
+    private let buttonStackView = UIStackView().then {
+        $0.spacing = 24
+    }
+
+    private let cancelButton = DefaultButton(type: .cancel).then {
+        $0.setShadow(type: .large)
+    }
+
+    private let startButton = DefaultButton(type: .start).then {
+        $0.setShadow(type: .large)
+    }
+
+    // MARK: - Init, Deinit, required
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        timePicker.delegate = self
+        timePicker.dataSource = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Layout Cycle
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        addButton.updateShadowPath()
+        cancelButton.updateShadowPath()
+        startButton.updateShadowPath()
+
+        timeStackView.snp.removeConstraints()
+        timeStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 28)
+            $0.centerY.equalToSuperview()
+            $0.width.equalToSuperview().inset(8)
+        }
+    }
+
+    // MARK: - Layout Helper
+
+    override func setLayout() {
+        contentView.addSubviews(idleStackView, addStackView)
+
+        idleStackView.addArrangedSubviews(bellImageView, addButton)
+
+        addStackView.addArrangedSubviews(timePicker, buttonStackView)
+
+        buttonStackView.addArrangedSubviews(cancelButton, startButton)
+
+        timePicker.addSubviews(timeStackView)
+
+        timeStackView.addArrangedSubviews(hourLabel, munuteLabel, secondLabel)
+
+        idleStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        bellImageView.snp.makeConstraints {
+            $0.size.equalTo(190)
+        }
+
+        addStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension TimerAddHeader {
+    enum State {
+        case idle
+        case add
+    }
+}
+
+extension TimerAddHeader: UIPickerViewDelegate, UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        3
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch component {
+        case 0: return 24
+        case 1,2: return 60
+        default: return 0
+        }
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        "\(row)"
+    }
+}

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerAddHeader.swift
@@ -96,7 +96,7 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
 
         timeStackView.snp.removeConstraints()
         timeStackView.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 28)
+            $0.leading.equalToSuperview().inset(timePicker.rowSize(forComponent: 0).width / 2 + 36)
             $0.centerY.equalToSuperview()
             $0.width.equalToSuperview().inset(8)
         }
@@ -118,7 +118,9 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
         timeStackView.addArrangedSubviews(hourLabel, munuteLabel, secondLabel)
 
         idleStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(32)
         }
 
         bellImageView.snp.makeConstraints {
@@ -126,7 +128,9 @@ final class TimerAddHeader: BaseTableViewHeaderFooterView {
         }
 
         addStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(32)
         }
     }
 }

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
@@ -52,6 +52,12 @@ final class TimerCurrentCell: BaseTableViewCell {
         setProgressPath()
     }
 
+    // MARK: - Style Helper
+
+    override func setStyles() {
+        backgroundColor = .clear
+    }
+
     // MARK: - Layout Helper
 
     override func setLayout() {

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
@@ -68,6 +68,7 @@ final class TimerCurrentCell: BaseTableViewCell {
 
     override func setStyles() {
         backgroundColor = .clear
+        selectionStyle = .none
     }
 
     // MARK: - Layout Helper

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
@@ -44,6 +44,18 @@ final class TimerCurrentCell: BaseTableViewCell {
         $0.strokeEnd = 1.0
     }
 
+    // MARK: - Init, Deinit, required
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        updateState(to: .running)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
     // MARK: - Layout Cycles
 
     override func layoutSubviews() {
@@ -100,8 +112,28 @@ final class TimerCurrentCell: BaseTableViewCell {
         updateProgress(value: progress)
     }
 
+    func updateState(to state: TimerState) {
+        timeLabel.textColor = state.labelColor
+        timeKRLabel.textColor = state.labelColor
+        controlButton.isSelected = state == .running
+    }
+
     /// value: 0~1 사이의 값으로 진행도를 나타냄
     func updateProgress(value: CGFloat) {
         progressLayer.strokeEnd = value
+    }
+}
+
+extension TimerCurrentCell {
+    enum TimerState {
+        case running
+        case pause
+
+        var labelColor: UIColor {
+            switch self {
+            case .running: .neutral1000
+            case .pause: .neutral300
+            }
+        }
     }
 }

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerCurrentCell.swift
@@ -1,0 +1,101 @@
+//
+//  TimerCurrentCell.swift
+//  Beontteuk
+//
+//  Created by 곽다은 on 5/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class TimerCurrentCell: BaseTableViewCell {
+
+    // MARK: - UI Components
+
+    private let labelStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+    }
+
+    private let timeLabel = UILabel().then {
+        $0.textColor = .neutral1000
+        $0.font = .systemFont(ofSize: 50, weight: .medium)
+    }
+
+    private let timeKRLabel = UILabel().then {
+        $0.textColor = .neutral1000
+        $0.font = .systemFont(ofSize: 20, weight: .medium)
+    }
+
+    private let controlButton = UIButton().then {
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 35, weight: .regular)
+        let playImage = UIImage(systemName: "play.fill", withConfiguration: imageConfig)
+        let pauseImage = UIImage(systemName: "pause.fill", withConfiguration: imageConfig)
+        $0.setImage(playImage, for: .normal)
+        $0.setImage(pauseImage, for: .selected)
+        $0.tintColor = .primary500
+    }
+
+    private let progressLayer = CAShapeLayer().then {
+        $0.strokeColor = UIColor.primary500.cgColor
+        $0.fillColor = UIColor.clear.cgColor
+        $0.lineWidth = 5
+        $0.strokeEnd = 1.0
+    }
+
+    // MARK: - Layout Cycles
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        setProgressPath()
+    }
+
+    // MARK: - Layout Helper
+
+    override func setLayout() {
+        contentView.addSubviews(labelStackView, controlButton)
+
+        labelStackView.addArrangedSubviews(timeLabel, timeKRLabel)
+
+        controlButton.layer.addSublayer(progressLayer)
+
+        labelStackView.snp.makeConstraints {
+            $0.verticalEdges.leading.equalToSuperview().inset(20)
+        }
+
+        controlButton.snp.makeConstraints {
+            $0.leading.equalTo(labelStackView.snp.trailing).offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalTo(labelStackView)
+            $0.size.equalTo(70)
+        }
+    }
+
+    // MARK: - Methods
+
+    private func setProgressPath() {
+        progressLayer.frame = controlButton.bounds
+        let center = CGPoint(x: progressLayer.bounds.midX, y: progressLayer.bounds.midY)
+        let circularPath = UIBezierPath(
+            arcCenter: center,
+            radius: 32.5,// (button frame size - stroke line width) / 2
+            startAngle: -.pi / 2,
+            endAngle: .pi * 3 / 2,
+            clockwise: true
+        )
+        progressLayer.path = circularPath.cgPath
+    }
+
+    func configureCell(time: String, timeKR: String, progress: CGFloat) {
+        timeLabel.text = time
+        timeKRLabel.text = timeKR
+        updateProgress(value: progress)
+    }
+
+    /// value: 0~1 사이의 값으로 진행도를 나타냄
+    func updateProgress(value: CGFloat) {
+        progressLayer.strokeEnd = value
+    }
+}

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
@@ -40,6 +40,12 @@ final class TimerRecentCell: BaseTableViewCell {
         $0.layer.cornerRadius = 35
     }
 
+    // MARK: - Style Helper
+
+    override func setStyles() {
+        backgroundColor = .clear
+    }
+
     // MARK: - Layout Helper
 
     override func setLayout() {

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
@@ -1,0 +1,73 @@
+//
+//  TimerRecentCell.swift
+//  Beontteuk
+//
+//  Created by 곽다은 on 5/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class TimerRecentCell: BaseTableViewCell {
+
+    // MARK: - UI Components
+
+    private let labelStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+    }
+
+    private let timeLabel = UILabel().then {
+        $0.textColor = .neutral1000
+        $0.font = .systemFont(ofSize: 50, weight: .medium)
+    }
+
+    private let timeKRLabel = UILabel().then {
+        $0.textColor = .neutral1000
+        $0.font = .systemFont(ofSize: 20, weight: .medium)
+    }
+
+    private let startButton = UIButton().then {
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 35, weight: .regular)
+        let playImage = UIImage(systemName: "play.fill", withConfiguration: imageConfig)
+        $0.setImage(playImage, for: .normal)
+        $0.tintColor = .primary300
+    }
+
+    private let circleView = UIView().then {
+        $0.backgroundColor = .primary200
+        $0.layer.cornerRadius = 35
+    }
+
+    // MARK: - Layout Helper
+
+    override func setLayout() {
+        contentView.addSubviews(labelStackView, circleView)
+
+        labelStackView.addArrangedSubviews(timeLabel, timeKRLabel)
+
+        circleView.addSubviews(startButton)
+
+        labelStackView.snp.makeConstraints {
+            $0.verticalEdges.leading.equalToSuperview().inset(20)
+        }
+
+        circleView.snp.makeConstraints {$0.leading.equalTo(labelStackView.snp.trailing).offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalTo(labelStackView)
+            $0.size.equalTo(70)
+        }
+
+        startButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    // MARK: - Methods
+
+    func configureCell(time: String, timeKR: String) {
+        timeLabel.text = time
+        timeKRLabel.text = timeKR
+    }
+}

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
@@ -19,12 +19,12 @@ final class TimerRecentCell: BaseTableViewCell {
     }
 
     private let timeLabel = UILabel().then {
-        $0.textColor = .neutral1000
+        $0.textColor = .neutral300
         $0.font = .systemFont(ofSize: 50, weight: .medium)
     }
 
     private let timeKRLabel = UILabel().then {
-        $0.textColor = .neutral1000
+        $0.textColor = .neutral300
         $0.font = .systemFont(ofSize: 20, weight: .medium)
     }
 

--- a/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
+++ b/Beontteuk/Presentation/Timer/View/Subview/TimerRecentCell.swift
@@ -44,6 +44,7 @@ final class TimerRecentCell: BaseTableViewCell {
 
     override func setStyles() {
         backgroundColor = .clear
+        selectionStyle = .none
     }
 
     // MARK: - Layout Helper

--- a/Beontteuk/Presentation/Timer/View/TimerView.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerView.swift
@@ -11,18 +11,13 @@ import Then
 
 final class TimerView: BaseView {
 
-    enum TimerSection: Hashable, CaseIterable {
-        case current
-        case recent
-    }
-
     // MARK: - Properties
 
     private var dataSource: UITableViewDiffableDataSource<TimerSection, TimerItem>?
 
     // MARK: - UI Components
 
-    private let tableView = UITableView().then {
+    private let tableView = UITableView(frame: .zero, style: .grouped).then {
         $0.backgroundColor = .clear
         $0.register(TimerCurrentCell.self, forCellReuseIdentifier: TimerCurrentCell.className)
         $0.register(TimerRecentCell.self, forCellReuseIdentifier: TimerRecentCell.className)
@@ -46,10 +41,12 @@ final class TimerView: BaseView {
         addSubviews(tableView)
 
         tableView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
-            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+            $0.top.directionalHorizontalEdges.equalTo(safeAreaLayoutGuide)
+            $0.bottom.equalToSuperview()
         }
     }
+
+    // MARK: - DataSource Helper
 
     private func setDataSource() {
         dataSource = .init(tableView: tableView, cellProvider: { tableView, indexPath, item in
@@ -90,5 +87,11 @@ final class TimerView: BaseView {
         snapshot.appendItems(TimerItem.currentItems, toSection: .current)
         snapshot.appendItems(TimerItem.recentItems, toSection: .recent)
         dataSource?.apply(snapshot)
+    }
+
+    // MARK: - Methods
+
+    func setTableViewDelegate(_ delegate: UITableViewDelegate) {
+        tableView.delegate = delegate
     }
 }

--- a/Beontteuk/Presentation/Timer/View/TimerView.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerView.swift
@@ -5,4 +5,90 @@
 //  Created by 백래훈 on 5/20/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import Then
+
+final class TimerView: BaseView {
+
+    enum TimerSection: Hashable, CaseIterable {
+        case current
+        case recent
+    }
+
+    // MARK: - Properties
+
+    private var dataSource: UITableViewDiffableDataSource<TimerSection, TimerItem>?
+
+    // MARK: - UI Components
+
+    private let tableView = UITableView().then {
+        $0.backgroundColor = .clear
+        $0.register(TimerCurrentCell.self, forCellReuseIdentifier: TimerCurrentCell.className)
+        $0.register(TimerRecentCell.self, forCellReuseIdentifier: TimerRecentCell.className)
+        $0.showsVerticalScrollIndicator = false
+    }
+
+    // MARK: - Init, Deinit, required
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setDataSource()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Layout Helper
+
+    override func setLayout() {
+        addSubviews(tableView)
+
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+        }
+    }
+
+    private func setDataSource() {
+        dataSource = .init(tableView: tableView, cellProvider: { tableView, indexPath, item in
+            let section = TimerSection.allCases[indexPath.section]
+            switch section {
+            case .current:
+                let cell = tableView.dequeueReusableCell(
+                    withIdentifier: TimerCurrentCell.className,
+                    for: indexPath
+                ) as! TimerCurrentCell
+
+                if let timer = item.current {
+                    cell.configureCell(
+                        time: timer.time,
+                        timeKR: timer.timeKR,
+                        progress: timer.progress
+                    )
+                }
+
+                return cell
+
+            case .recent:
+                let cell = tableView.dequeueReusableCell(
+                    withIdentifier: TimerRecentCell.className,
+                    for: indexPath
+                ) as! TimerRecentCell
+
+                if let timer = item.recent {
+                    cell.configureCell(time: timer.time, timeKR: timer.timeKR)
+                }
+
+                return cell
+            }
+        })
+
+        guard var snapshot = dataSource?.snapshot() else { return }
+        snapshot.appendSections(TimerSection.allCases)
+        snapshot.appendItems(TimerItem.currentItems, toSection: .current)
+        snapshot.appendItems(TimerItem.recentItems, toSection: .recent)
+        dataSource?.apply(snapshot)
+    }
+}

--- a/Beontteuk/Presentation/Timer/View/TimerViewController.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerViewController.swift
@@ -52,11 +52,11 @@ extension TimerViewController: UITableViewDelegate {
         }
     }
 
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         let section = TimerSection.allCases[section]
         switch section {
-        case .current: return 300
-        case .recent: return 40
+        case .current: return 334
+        case .recent: return 44
         }
     }
 }

--- a/Beontteuk/Presentation/Timer/View/TimerViewController.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerViewController.swift
@@ -20,4 +20,43 @@ final class TimerViewController: BaseViewController {
     override func loadView() {
         view = timerView
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        timerView.setTableViewDelegate(self)
+    }
+}
+
+extension TimerViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let section = TimerSection.allCases[section]
+        switch section {
+        case .current:
+            let header = TimerAddHeader()
+            return header
+        case .recent:
+            let label = UILabel().then {
+                $0.text = "최근 항목"
+                $0.font = .systemFont(ofSize: 20, weight: .semibold)
+            }
+
+            let containerView = UIView()
+            containerView.addSubview(label)
+            label.snp.makeConstraints {
+                $0.top.directionalHorizontalEdges.equalToSuperview().inset(16)
+                $0.bottom.equalToSuperview().inset(8)
+            }
+
+            return containerView
+        }
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        let section = TimerSection.allCases[section]
+        switch section {
+        case .current: return 300
+        case .recent: return 40
+        }
+    }
 }

--- a/Beontteuk/Presentation/Timer/View/TimerViewController.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerViewController.swift
@@ -1,0 +1,23 @@
+//
+//  TimerViewController.swift
+//  Beontteuk
+//
+//  Created by 곽다은 on 5/21/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class TimerViewController: BaseViewController {
+
+    // MARK: - UI Components
+
+    private let timerView = TimerView()
+
+    // MARK: - View Life Cycle
+
+    override func loadView() {
+        view = timerView
+    }
+}

--- a/Beontteuk/Presentation/Timer/View/TimerViewController.swift
+++ b/Beontteuk/Presentation/Timer/View/TimerViewController.swift
@@ -25,6 +25,7 @@ final class TimerViewController: BaseViewController {
         super.viewDidLoad()
 
         timerView.setTableViewDelegate(self)
+        navigationItem.leftBarButtonItem = CustomUIBarButtonItem(type: .edit(action: {}))
     }
 }
 

--- a/Beontteuk/Resources/Assets.xcassets/Color/primary200.colorset/Contents.json
+++ b/Beontteuk/Resources/Assets.xcassets/Color/primary200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "221",
+          "red" : "202"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 사용중인 타이머 셀 UI 구현
 - 최근 사용한 타이머 셀 UI 구현
 - 타이머 테이블뷰 구현
 - 레이아웃 확인용도로 목데이터를 추가해두었습니다. 기능 구현하면서 삭제하겠습니다.
 - 타이머 추가 헤더 구현

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- PickerView에 고정 레이블을 추가하는 기능이 없어서 시간/분/초 레이블을 포함하는 TimeStackView를 PickerView의 subview로 추가하여 구현했습니다. 회전 등에 의한 레이아웃 재계산 시 TimeStackView의 leading 제약을 업데이트해주는 방식으로 위치를 고정시켰습니다.
- asset에 없는 색을 사용해야해서 primary200으로 추가했습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone Pro 16 | <img src = "https://github.com/user-attachments/assets/15fb9e0c-80bb-482b-9a82-654867ec1ff0" width ="250">|

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #2
