### PR TITLE
[Feat] - 세계 시계 탭 UI 구성 및 Rx 바인딩 적용

### DIFF
--- a/Beontteuk/Presentation/Shared/Extension/Extension.swift
+++ b/Beontteuk/Presentation/Shared/Extension/Extension.swift
@@ -107,3 +107,9 @@ extension UIImage {
         return result ?? self
     }
 }
+
+extension UIFont {
+    static func lightFont() -> UIFont {
+        return UIFont.systemFont(ofSize: 55, weight: .light)
+    }
+}

--- a/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
@@ -48,11 +48,13 @@ extension AddButton {
     enum ButtonType {
         case alarm
         case timer
+        case city
 
         var text: String {
             switch self {
             case .alarm: "알람 추가"
             case .timer: "타이머 추가"
+            case .city: "도시 추가"
             }
         }
     }

--- a/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/AddButton.swift
@@ -41,6 +41,7 @@ final class AddButton: UIButton {
         config.contentInsets = .init(top: 12, leading: 24, bottom: 12, trailing: 24)
 
         self.configuration = config
+        self.setNeedsUpdateConfiguration()
     }
 }
 
@@ -59,4 +60,3 @@ extension AddButton {
         }
     }
 }
-

--- a/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableHeaderView.swift
+++ b/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableHeaderView.swift
@@ -1,0 +1,46 @@
+//
+//  WorldClockTableHeaderView.swift
+//  Beontteuk
+//
+//  Created by 백래훈 on 5/23/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WorldClockTableHeaderView: BaseTableViewHeaderFooterView {
+    //MARK: UI Components
+    let worldClockImage = UIImageView().then {
+        $0.image = UIImage(resource: .worldclock)
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    let addButton = AddButton(type: .city).then {
+        $0.setShadow(type: .large)
+    }
+    
+    override func setStyles() {
+        super.setStyles()
+        
+        self.contentView.addSubviews(worldClockImage, addButton)
+        
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        
+        worldClockImage.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.size.equalTo(200)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.top.equalTo(worldClockImage.snp.bottom).offset(16)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(20).priority(.high)
+        }
+    }
+    
+}

--- a/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableHeaderView.swift
+++ b/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableHeaderView.swift
@@ -12,24 +12,44 @@ import Then
 
 final class WorldClockTableHeaderView: BaseTableViewHeaderFooterView {
     //MARK: UI Components
-    let worldClockImage = UIImageView().then {
+    private let worldClockImage = UIImageView().then {
         $0.image = UIImage(resource: .worldclock)
         $0.contentMode = .scaleAspectFit
     }
     
-    let addButton = AddButton(type: .city).then {
+    private let addButton = AddButton(type: .city).then {
         $0.setShadow(type: .large)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        addButton.updateShadowPath()
+        
+        if let tableView = self.superview as? UITableView {
+            let targetSize = CGSize(width: tableView.frame.width, height: 0)
+            let fittingSize = self.systemLayoutSizeFitting(targetSize)
+            if self.frame.height != fittingSize.height {
+                self.frame.size.height = fittingSize.height
+                tableView.tableHeaderView = self // 트리거해서 반영
+            }
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        let fittingSize = systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        return CGSize(width: fittingSize.width, height: fittingSize.height)
     }
     
     override func setStyles() {
         super.setStyles()
         
-        self.contentView.addSubviews(worldClockImage, addButton)
-        
     }
     
     override func setLayout() {
         super.setLayout()
+        
+        self.contentView.addSubviews(worldClockImage, addButton)
         
         worldClockImage.snp.makeConstraints {
             $0.top.equalToSuperview()
@@ -39,8 +59,9 @@ final class WorldClockTableHeaderView: BaseTableViewHeaderFooterView {
         
         addButton.snp.makeConstraints {
             $0.top.equalTo(worldClockImage.snp.bottom).offset(16)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(20).priority(.high)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+            $0.bottom.equalToSuperview().offset(-16)
         }
     }
-    
 }

--- a/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
+++ b/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
@@ -29,7 +29,7 @@ final class WorldClockTableViewCell: BaseTableViewCell {
     }
     
     let clockLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 55, weight: .light)
+        $0.font = .lightFont()
         $0.textColor = .label
     }
     

--- a/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
+++ b/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
@@ -13,13 +13,11 @@ import Then
 final class WorldClockTableViewCell: BaseTableViewCell {
     //MARK: UI Components
     let dayTimeLabel = UILabel().then {
-        $0.text = "오늘, -8시간"
         $0.font = .systemFont(ofSize: 13, weight: .regular)
         $0.textColor = .systemGray
     }
     
     let cityLabel = UILabel().then {
-        $0.text = "런던"
         $0.font = .systemFont(ofSize: 25, weight: .regular)
         $0.textColor = .label
     }
@@ -31,8 +29,7 @@ final class WorldClockTableViewCell: BaseTableViewCell {
     }
     
     let clockLabel = UILabel().then {
-        $0.text = "09:00"
-        $0.font = .systemFont(ofSize: 50, weight: .regular)
+        $0.font = .systemFont(ofSize: 55, weight: .light)
         $0.textColor = .label
     }
     
@@ -40,14 +37,17 @@ final class WorldClockTableViewCell: BaseTableViewCell {
     override func setStyles() {
         super.setStyles()
         
-        self.contentView.addSubviews(verticalStackView, clockLabel)
-        self.verticalStackView.addArrangedSubviews(dayTimeLabel, cityLabel)
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
         
     }
     
     //MARK: SetLayout
     override func setLayout() {
         super.setLayout()
+        
+        self.contentView.addSubviews(verticalStackView, clockLabel)
+        self.verticalStackView.addArrangedSubviews(dayTimeLabel, cityLabel)
         
         verticalStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
@@ -56,7 +56,13 @@ final class WorldClockTableViewCell: BaseTableViewCell {
         
         clockLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().offset(-16)
-            $0.centerY.equalToSuperview()
+            $0.verticalEdges.equalToSuperview().inset(8)
         }
+    }
+    
+    func configureCell(with: WorldClockDummy) {
+        self.dayTimeLabel.text = with.timeDifference
+        self.cityLabel.text = with.city
+        self.clockLabel.text = with.time
     }
 }

--- a/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
+++ b/Beontteuk/Presentation/WorldClock/Cell/WorldClockTableViewCell.swift
@@ -1,0 +1,62 @@
+//
+//  WorldClockTableViewCell.swift
+//  Beontteuk
+//
+//  Created by 백래훈 on 5/23/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WorldClockTableViewCell: BaseTableViewCell {
+    //MARK: UI Components
+    let dayTimeLabel = UILabel().then {
+        $0.text = "오늘, -8시간"
+        $0.font = .systemFont(ofSize: 13, weight: .regular)
+        $0.textColor = .systemGray
+    }
+    
+    let cityLabel = UILabel().then {
+        $0.text = "런던"
+        $0.font = .systemFont(ofSize: 25, weight: .regular)
+        $0.textColor = .label
+    }
+    
+    let verticalStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .equalSpacing
+        $0.alignment = .leading
+    }
+    
+    let clockLabel = UILabel().then {
+        $0.text = "09:00"
+        $0.font = .systemFont(ofSize: 50, weight: .regular)
+        $0.textColor = .label
+    }
+    
+    //MARK: SetStyles
+    override func setStyles() {
+        super.setStyles()
+        
+        self.contentView.addSubviews(verticalStackView, clockLabel)
+        self.verticalStackView.addArrangedSubviews(dayTimeLabel, cityLabel)
+        
+    }
+    
+    //MARK: SetLayout
+    override func setLayout() {
+        super.setLayout()
+        
+        verticalStackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        clockLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-16)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
@@ -13,8 +13,10 @@ import Then
 final class WorldClockView: BaseView {
     //MARK: UI Components
     private let worldClockTableView = UITableView().then {
-        $0.register(<#T##nib: UINib?##UINib?#>, forCellReuseIdentifier: <#T##String#>)
-        $0.register(<#T##nib: UINib?##UINib?#>, forHeaderFooterViewReuseIdentifier: <#T##String#>)
+        $0.register(WorldClockTableViewCell.self, forCellReuseIdentifier: WorldClockTableViewCell.className)
+        $0.register(WorldClockTableHeaderView.self, forHeaderFooterViewReuseIdentifier: WorldClockTableHeaderView.className)
+        $0.backgroundColor = .clear
+        $0.tableHeaderView = WorldClockTableHeaderView()
     }
     
     //MARK: SetStyles

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
@@ -12,6 +12,13 @@ import Then
 
 final class WorldClockView: BaseView {
     //MARK: UI Components
+    private let navigationBar = UINavigationBar().then {
+        $0.backgroundColor = .clear
+        $0.setBackgroundImage(UIImage(), for: .default)
+        $0.shadowImage = UIImage()
+        $0.isTranslucent = true
+    }
+    
     private let worldClockTableView = UITableView().then {
         $0.register(WorldClockTableViewCell.self, forCellReuseIdentifier: WorldClockTableViewCell.className)
         $0.register(WorldClockTableHeaderView.self, forHeaderFooterViewReuseIdentifier: WorldClockTableHeaderView.className)
@@ -23,16 +30,24 @@ final class WorldClockView: BaseView {
     override func setStyles() {
         super.setStyles()
         
-        self.addSubview(worldClockTableView)
-        
+        self.addSubviews(worldClockTableView, navigationBar)
+        setNavigationBar()
     }
     
     //MARK: SetLayouts
     override func setLayout() {
         super.setLayout()
         
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+        
         worldClockTableView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
         }
     }
     
@@ -41,4 +56,22 @@ final class WorldClockView: BaseView {
         return worldClockTableView
     }
     
+    func makeEmptyView() -> UIView {
+        let label = UILabel()
+        label.text = "세계 시계 없음"
+        label.textAlignment = .center
+        label.textColor = .systemGray
+        label.font = .systemFont(ofSize: 25, weight: .medium)
+        return label
+    }
+    
+    //MARK: Private Methods
+    private func setNavigationBar() {
+        let item = UINavigationItem(title: "")
+        item.leftBarButtonItem = CustomUIBarButtonItem(type: .edit {
+            print("Edit Button Tapped")
+        })
+        
+        self.navigationBar.setItems([item], animated: true)
+    }
 }

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockView.swift
@@ -5,4 +5,38 @@
 //  Created by 백래훈 on 5/20/25.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+import Then
+
+final class WorldClockView: BaseView {
+    //MARK: UI Components
+    private let worldClockTableView = UITableView().then {
+        $0.register(<#T##nib: UINib?##UINib?#>, forCellReuseIdentifier: <#T##String#>)
+        $0.register(<#T##nib: UINib?##UINib?#>, forHeaderFooterViewReuseIdentifier: <#T##String#>)
+    }
+    
+    //MARK: SetStyles
+    override func setStyles() {
+        super.setStyles()
+        
+        self.addSubview(worldClockTableView)
+        
+    }
+    
+    //MARK: SetLayouts
+    override func setLayout() {
+        super.setLayout()
+        
+        worldClockTableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    //MARK: Methods
+    func getWorldClockTableView() -> UITableView {
+        return worldClockTableView
+    }
+    
+}

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import RxSwift
+import RxRelay
 
 struct WorldClockDummy {
     let city: String
@@ -28,7 +29,7 @@ final class WorldClockViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let dummyData = Observable.just([
+        let dummyData = BehaviorRelay<[WorldClockDummy]>(value: [
             WorldClockDummy(city: "런던", timeDifference: "오늘, -8시간", time: "09:00"),
             WorldClockDummy(city: "도쿄", timeDifference: "오늘, +0시간", time: "17:00"),
             WorldClockDummy(city: "뉴욕", timeDifference: "어제, -13시간", time: "04:00"),
@@ -44,21 +45,23 @@ final class WorldClockViewController: BaseViewController {
         ])
         
         dummyData
+            .do(onNext: { [weak self] items in
+                guard let self else { return }
+                self.worldClockView.getWorldClockTableView().backgroundView = items.isEmpty ? self.worldClockView.makeEmptyView() : nil
+            })
             .bind(to: worldClockView.getWorldClockTableView().rx.items(
                 cellIdentifier: WorldClockTableViewCell.className,
                 cellType: WorldClockTableViewCell.self)
             ) { row, model, cell in
-                cell.configureCell(with: model) // You'll need to implement this method
+                cell.configureCell(with: model)
             }
             .disposed(by: disposeBag)
-        
-        
     }
     
     override func setStyles() {
         super.setStyles()
         
-//        self.navigationController?.isNavigationBarHidden = true
+        self.navigationController?.isNavigationBarHidden = true
     }
     
     override func setLayout() {

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
@@ -7,16 +7,58 @@
 
 import UIKit
 
+import RxSwift
+
+struct WorldClockDummy {
+    let city: String
+    let timeDifference: String
+    let time: String
+}
+
 final class WorldClockViewController: BaseViewController {
+    
+    private let worldClockView = WorldClockView()
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = worldClockView
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let dummyData = Observable.just([
+            WorldClockDummy(city: "런던", timeDifference: "오늘, -8시간", time: "09:00"),
+            WorldClockDummy(city: "도쿄", timeDifference: "오늘, +0시간", time: "17:00"),
+            WorldClockDummy(city: "뉴욕", timeDifference: "어제, -13시간", time: "04:00"),
+            WorldClockDummy(city: "서울", timeDifference: "오늘, +0시간", time: "17:00"),
+            WorldClockDummy(city: "런던", timeDifference: "오늘, -8시간", time: "09:00"),
+            WorldClockDummy(city: "도쿄", timeDifference: "오늘, +0시간", time: "17:00"),
+            WorldClockDummy(city: "뉴욕", timeDifference: "어제, -13시간", time: "04:00"),
+            WorldClockDummy(city: "서울", timeDifference: "오늘, +0시간", time: "17:00"),
+            WorldClockDummy(city: "런던", timeDifference: "오늘, -8시간", time: "09:00"),
+            WorldClockDummy(city: "도쿄", timeDifference: "오늘, +0시간", time: "17:00"),
+            WorldClockDummy(city: "뉴욕", timeDifference: "어제, -13시간", time: "04:00"),
+            WorldClockDummy(city: "서울", timeDifference: "오늘, +0시간", time: "17:00")
+        ])
+        
+        dummyData
+            .bind(to: worldClockView.getWorldClockTableView().rx.items(
+                cellIdentifier: WorldClockTableViewCell.className,
+                cellType: WorldClockTableViewCell.self)
+            ) { row, model, cell in
+                cell.configureCell(with: model) // You'll need to implement this method
+            }
+            .disposed(by: disposeBag)
+        
         
     }
     
     override func setStyles() {
         super.setStyles()
         
+//        self.navigationController?.isNavigationBarHidden = true
     }
     
     override func setLayout() {

--- a/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
+++ b/Beontteuk/Presentation/WorldClock/View/WorldClockViewController.swift
@@ -21,8 +21,6 @@ final class WorldClockViewController: BaseViewController {
     private let worldClockView = WorldClockView()
     
     override func loadView() {
-        super.loadView()
-        
         view = worldClockView
     }
     


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 세계 시계 탭의 기본 UI 컴포넌트 구성
 - WorldClockViewController 레이아웃 구성
 - 테이블 뷰 셀: WorldClockTableViewCell 생성 (도시명, 시간 차이, 현재 시각 표시)
 - 테이블 뷰 헤더: WorldClockTableHeaderView 생성 (아이콘 + “도시 추가” 버튼 포함)
 - AddButton에 .city 타입 추가 및 UI 반영
 - 테이블 뷰 내부 컴포넌트 등록(register) 및 UI 스타일 지정
 - Rx를 이용한 더미 데이터 바인딩 처리 및 뷰 테스트
 - configureCell()을 통한 셀 내 데이터 표시 처리
 - 세계 시계 데이터가 없는 경우 '세계 시계 없음' 문구 처리
 - Custom NavigationBar를 상단에 고정하여 삭제 버튼 추가
 - NavigationBar 배경색, 섀도우 투명 처리로 스크롤 시에도 배경색과 동일하게 비춰지도록 구현

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- Rx를 사용해 TableView에 더미 데이터를 바인딩하고 UI가 의도대로 렌더링되는지 확인
- TableHeaderView는 height를 자동 계산해 tableHeaderView로 갱신되도록 처리

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| **세계 시계 탭**</br>Custom Navigation Bar **적용**</br>UITabelView 데이터 **미존재**</br>[iPhone 16 Pro Max] | <img src = "https://github.com/user-attachments/assets/6611f277-32cc-43f4-9b8c-9da6dec504ec" width ="250"> |
| **세계 시계 탭**</br>Custom Navigation Bar **적용**</br>UITabelView 데이터 **존재**</br>[iPhone 16 Pro Max] | <img src = "https://github.com/user-attachments/assets/72006a8e-68ba-4598-aafb-60f6cb387855" width ="250"> |
| **세계 시계 탭**</br>Custom Navigation Bar</br>**스크롤 상태**</br>[iPhone 16 Pro Max] | <img src = "https://github.com/user-attachments/assets/8ad18f49-dbd4-46a9-b6d8-bcea88d2e0ba" width ="250"> |

## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #29 
