### PR TITLE
Feature: #24 - 스톱워치 버튼 상태 구현 및 공용 DefaultButton 수정

### DIFF
--- a/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
@@ -15,30 +15,26 @@ final class DefaultButton: UIButton {
 
         var config = UIButton.Configuration.plain()
 
-        switch type {
-        case .reset, .start, .lap, .stop, .cancel:
-            config.baseForegroundColor = type.fgColor
-            config.titleAlignment = .center
-            config.attributedTitle = {
-                var attributedTitle = AttributedString(type.text)
-                attributedTitle.font = UIFont.systemFont(
-                    ofSize: type.fontSize,
-                    weight: .medium
-                )
-                return attributedTitle
-            }()
+        config.baseForegroundColor = type.fgColor
+        config.titleAlignment = .center
+        config.attributedTitle = {
+            var attributedTitle = AttributedString(type.text)
+            attributedTitle.font = UIFont.systemFont(
+                ofSize: type.fontSize,
+                weight: .medium
+            )
+            return attributedTitle
+        }()
 
-            self.configuration = config
-            self.layer.cornerRadius = 16
-            self.backgroundColor = type.bgColor
-            self.setShadow(type: .large)
+        self.configuration = config
+        self.layer.cornerRadius = 16
+        self.backgroundColor = type.bgColor
 
-            self.snp.makeConstraints {
-                $0.height.equalTo(type.height)
-            }
+        self.snp.makeConstraints {
+            $0.height.equalTo(type.height)
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
+++ b/Beontteuk/Presentation/Shared/ViewComponent/DefaultButton.swift
@@ -10,9 +10,34 @@ import SnapKit
 
 final class DefaultButton: UIButton {
 
-    init(type: DefaultButtonType) {
-        super.init(frame: .zero)
+    // MARK: - Properties
+    
+    private var type: DefaultButtonType
 
+    // MARK: - Initializer, Deinit, requiered
+
+    init(type: DefaultButtonType) {
+        self.type = type
+        super.init(frame: .zero)
+        configureDefaultButton()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout Helper
+
+    private func setLayout() {
+        self.snp.makeConstraints {
+            $0.height.equalTo(type.height)
+        }
+    }
+
+    // MARK: - Methods
+
+    private func configureDefaultButton() {
         var config = UIButton.Configuration.plain()
 
         config.baseForegroundColor = type.fgColor
@@ -29,14 +54,12 @@ final class DefaultButton: UIButton {
         self.configuration = config
         self.layer.cornerRadius = 16
         self.backgroundColor = type.bgColor
-
-        self.snp.makeConstraints {
-            $0.height.equalTo(type.height)
-        }
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    ///
+    func updateButtonType(type: DefaultButtonType) {
+        self.type = type
+        configureDefaultButton()
     }
 }
 

--- a/Beontteuk/Presentation/StopWatch/View/LapCell.swift
+++ b/Beontteuk/Presentation/StopWatch/View/LapCell.swift
@@ -68,10 +68,6 @@ final class LapCell: BaseTableViewCell {
 
     // MARK: - Methods
 
-    func configureItems(_ lapModel: LapTestModel) {
-        self.lapLabel.text = lapModel.lap
-        self.lappedTimeLabel.text = lapModel.lappedTime
-        self.timeIntervalLabel.text = lapModel.timeInterval
-    }
+    func configureItems() { }
 }
 

--- a/Beontteuk/Presentation/StopWatch/View/StopWatchView.swift
+++ b/Beontteuk/Presentation/StopWatch/View/StopWatchView.swift
@@ -30,11 +30,11 @@ final class StopWatchView: BaseView {
         $0.spacing = 24
     }
 
-    let resetButton = DefaultButton(type: .lap).then {
+    let leftButton = DefaultButton(type: .lap).then {
         $0.setShadow(type: .large)
     }
 
-    let startButton = DefaultButton(type: .start).then {
+    let rightButton = DefaultButton(type: .start).then {
         $0.setShadow(type: .large)
     }
 
@@ -63,7 +63,7 @@ final class StopWatchView: BaseView {
         super.setLayout()
         
         addSubviews(iconImageView, timerLabel, stackView, tableView)
-        stackView.addArrangedSubviews(resetButton, startButton)
+        stackView.addArrangedSubviews(leftButton, rightButton)
 
         iconImageView.snp.makeConstraints {
             $0.size.equalTo(242)

--- a/Beontteuk/Presentation/StopWatch/View/StopWatchView.swift
+++ b/Beontteuk/Presentation/StopWatch/View/StopWatchView.swift
@@ -30,9 +30,13 @@ final class StopWatchView: BaseView {
         $0.spacing = 24
     }
 
-    let resetButton = DefaultButton(type: .lap)
+    let resetButton = DefaultButton(type: .lap).then {
+        $0.setShadow(type: .large)
+    }
 
-    let startButton = DefaultButton(type: .start)
+    let startButton = DefaultButton(type: .start).then {
+        $0.setShadow(type: .large)
+    }
 
     let tableView = UITableView().then {
         $0.register(LapCell.self, forCellReuseIdentifier: LapCell.className)
@@ -50,8 +54,14 @@ final class StopWatchView: BaseView {
 
     // MARK: - Layout Helper
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateShadowPath()
+    }
+
     override func setLayout() {
         super.setLayout()
+        
         addSubviews(iconImageView, timerLabel, stackView, tableView)
         stackView.addArrangedSubviews(resetButton, startButton)
 

--- a/Beontteuk/Presentation/StopWatch/ViewModel/StopWatchViewModel.swift
+++ b/Beontteuk/Presentation/StopWatch/ViewModel/StopWatchViewModel.swift
@@ -5,21 +5,79 @@
 //  Created by 백래훈 on 5/20/25.
 //
 
-struct LapTestModel {
-    var lap: String
-    var lappedTime: String
-    var timeInterval: String
+import RxSwift
+import RxRelay
+
+enum TimeState {
+    case initial
+    case progress
+    case pause
 }
 
 final class StopWatchViewModel {
 
-    let items: [LapTestModel] = [
-        LapTestModel(lap: "랩 1", lappedTime: "00:00.48", timeInterval: "00:00.48"),
-        LapTestModel(lap: "랩 2", lappedTime: "00:00.51", timeInterval: "00:00.03"),
-        LapTestModel(lap: "랩 3", lappedTime: "00:01.01", timeInterval: "00:00.10"),
-        LapTestModel(lap: "랩 4", lappedTime: "00:01.32", timeInterval: "00:00.31"),
-        LapTestModel(lap: "랩 5", lappedTime: "00:01.48", timeInterval: "00:00.16"),
-        LapTestModel(lap: "랩 6", lappedTime: "00:03.51", timeInterval: "00:02.03"),
-        LapTestModel(lap: "랩 7", lappedTime: "00:04.31", timeInterval: "00:00.40"),
-    ]
+    // MARK: - Action, State
+
+    enum StopWatchAction {
+        case leftButton
+        case rightButton
+    }
+
+    struct StopWatchState {
+        let timeSubject = BehaviorRelay<TimeState>(value: .initial)
+    }
+
+    // MARK: - Properties
+
+    var action = PublishRelay<StopWatchAction>()
+    var state = StopWatchState()
+    private let disposeBag = DisposeBag()
+
+    // MARK: - Initializer, Deinit, requiered
+
+    init() {
+        bindAction()
+    }
+
+    // MARK: - Bind
+
+    private func bindAction() {
+        action
+            .bind { [weak self] action in
+                guard let self else { return }
+
+                let timeState = state.timeSubject.value
+
+                switch action {
+                case .leftButton:
+                    switch timeState {
+                    case .initial:
+                        // TODO: CoreData
+                        self.state.timeSubject.accept(.progress)
+                    case .progress:
+                        // TODO: 랩 활성화 -> CoreData
+                        print("랩 찍힘")
+                    case .pause:
+                        // TODO: CoreData
+                        self.state.timeSubject.accept(.initial)
+                    }
+
+                case .rightButton:
+
+                    let timeState = state.timeSubject.value
+
+                    switch timeState {
+                    case .initial:
+                        // TODO: CoreData
+                        self.state.timeSubject.accept(.progress)
+                    case .progress:
+                        // TODO: CoreData
+                        self.state.timeSubject.accept(.pause)
+                    case .pause:
+                        // TODO: CoreData
+                        self.state.timeSubject.accept(.progress)
+                    }
+                }
+            }.disposed(by: disposeBag)
+    }
 }


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - `DefaultButton` 의 `setShadow` 코드 삭제 후, 사용하는 곳에서 지정
 - `DefaultButton` 의 `type` 을 뷰의 상태에 따라 변경할 수 있도록 수정
   - 기존에 `init` 으로 `DefaultButton`의 최초 인스턴스 생성시에만 `DefaultButtonType`을 지정할 수 있던 방법을, 
      외부의 상태에 따라서 `DefaultButton` 의 `type`을 변경할 수 있도록 수정
   - 생성한 `DefaultButton`의 인스턴스에 `updateButtonType(_:)` 메소드로 접근하여 `type` 변경
        ```swift
        // 추가된 updateButtonType(_:) 메소드
        func updateButtonType(type: DefaultButtonType) {
            self.type = type
            configureDefaultButton()
         }
      ```
      ```swift
      // 사용 예시
      stopWatchView.leftButton.updateButtonType(type: .lap)
      ```

 - 스톱워치의 초기, 진행, 정지 상태에 따른 버튼 상태 구현
    - 스톱워치가 초기 상태일 경우 (예. 00:00.00)
      - 왼쪽 버튼: 랩 (비활성화)
      - 오른쪽 버튼: 시작
    - 스톱워치가 진행중인 상태일 경우 (예. 00:08.23)
      - 왼쪽 버튼: 랩 (활성화)
      - 오른쪽 버튼: 중단
    - 스톱워치가 정지 상태일 경우 (예. 00:11.56)
      - 왼쪽 버튼: 재설정
      - 오른쪽 버튼: 시작

## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
- 변경된 공용 `DefaultButton`
- 스톱워치의 초기, 진행, 정지 상태에 따른 버튼 상태 구현

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone - 16 pro <br> 최종 GIF | <img src = "https://github.com/user-attachments/assets/a5721446-c10d-4234-b26d-2fe487d71901" width ="250">|
| iPhone - 16 pro <br> 스톱워치가 초기 상태일 경우 <br> 랩(비활), 시작 | <img src = "https://github.com/user-attachments/assets/05c84556-5e65-4652-b471-d31def0f388d" width ="250">|
| iPhone - 16 pro <br> 스톱워치가 진행중인 상태일 경우 <br> 랩(활성), 중단 | <img src = "https://github.com/user-attachments/assets/914ceed9-be81-4abe-9522-01ea764b2257" width ="250">|
| iPhone - 16 pro <br> 스톱워치가 정지 상태일 경우 <br> 재설정, 시작 | <img src = "https://github.com/user-attachments/assets/d4e3d48b-fa05-49ea-95f0-7d0e65818eee" width ="250">|


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #24 
